### PR TITLE
Remove SafeMath Usage

### DIFF
--- a/contracts/cycles/Cycles.sol
+++ b/contracts/cycles/Cycles.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import "contracts/abstract/admin/AuthorizedCaller.sol";
 
@@ -40,11 +39,8 @@ contract FxHashCycles is AuthorizedCaller {
     function isCycleOpen(uint256 _id, uint256 _timestamp) private view returns (bool) {
         CycleParams memory _cycle = cycles[_id];
         uint256 diff = SignedMath.abs(int256(int256(_timestamp) - int256(_cycle.start)));
-        uint256 cycle_relative = SafeMath.mod(
-            diff,
-            _cycle.openingDuration + _cycle.closingDuration
-        );
-        return cycle_relative < _cycle.openingDuration;
+        uint256 cycleRelative = diff % (_cycle.openingDuration + _cycle.closingDuration);
+        return cycleRelative < _cycle.openingDuration;
     }
 
     function areCyclesOpen(

--- a/contracts/moderation/ModerationTeam.sol
+++ b/contracts/moderation/ModerationTeam.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.18;
 
 import "contracts/abstract/admin/AuthorizedCaller.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
 
@@ -113,10 +112,7 @@ contract ModerationTeam is Ownable {
             for (uint256 i = 0; i < EnumerableSet.length(moderatorAddresses); i++) {
                 address recipient = EnumerableSet.at(moderatorAddresses, i);
                 uint256 share = moderators[recipient].share;
-                SafeTransferLib.safeTransferETH(
-                    recipient,
-                    SafeMath.div(SafeMath.mul(amount, share), sharesTotal)
-                );
+                SafeTransferLib.safeTransferETH(recipient, (amount * share) / sharesTotal);
             }
         }
     }


### PR DESCRIPTION
Solidity uses SafeMath by Default after 0.8.0.  The pattern now is to use `unchecked {}` for math that is known to be safe without concern of over/underflow